### PR TITLE
Some improvements

### DIFF
--- a/content.js
+++ b/content.js
@@ -13,7 +13,7 @@ if (pullRequestTitleElement) {
     idsToBeReplaced += id;
 
     var rawTrackerId = id.match(/\d+/g);
-    links += '<a href="https://www.pivotaltracker.com/n/projects/1227506/stories/' +
+    links += '<a href="https://www.pivotaltracker.com/story/show' +
     rawTrackerId +
     '" target="_blank">[#' +
     rawTrackerId +

--- a/content.js
+++ b/content.js
@@ -4,12 +4,20 @@
     return;
   }
 
-  let title = $title.innerHTML.replace(/(<a[^>]+>|<\/a>)/g, '');
+  chrome.storage.local.get('inlineLinks', (options) => {
+    let title = $title.innerHTML.replace(/(<a[^>]+>|⬆︎|<\/a>)/g, '');
 
-  title.match(/\[#\d+\]/g).forEach((tag) => {
-    const url = `https://www.pivotaltracker.com/story/show/${tag.match(/\d+/)}`;
-    title = title.replace(tag, `<a href="${url}" target="_blank">${tag}</a>`);
+    title.match(/\[#\d+\]/g).forEach((tag) => {
+      const url = `https://www.pivotaltracker.com/story/show/${tag.match(/\d+/)}`;
+      const attrs = `href="${url}" target="_blank"`;
+
+      const replacement = options.inlineLinks === false ?
+        `${tag}<a ${attrs}>⬆︎</a>` :
+        `<a ${attrs}>${tag}</a>`;
+
+      title = title.replace(tag, replacement);
+    });
+
+    $title.innerHTML = title;
   });
-
-  $title.innerHTML = title;
 })();

--- a/content.js
+++ b/content.js
@@ -1,7 +1,7 @@
 var pullRequestTitleElement = document.getElementsByClassName('js-issue-title')[0];
 
 if (pullRequestTitleElement) {
-  var title = pullRequestTitleElement.innerHTML;
+  var title = pullRequestTitleElement.innerHTML.replace(/(<a[^>]+>|<\/a>)/g, '');
 
   // Gets an array of matched ids: [[#12345], [#34563], ...]
   var trackerIds = title.match(/\[#(.*?)\]\s*/g);

--- a/content.js
+++ b/content.js
@@ -7,7 +7,7 @@
   chrome.storage.local.get('inlineLinks', (options) => {
     let title = $title.innerHTML.replace(/(<a[^>]+>|⬆︎|<\/a>)/g, '');
 
-    title.match(/\[#\d+\]/g).forEach((tag) => {
+    title.match(/#\d+(?=[\],\s\d#]*\])/g).forEach((tag) => {
       const url = `https://www.pivotaltracker.com/story/show/${tag.match(/\d+/)}`;
       const attrs = `href="${url}" target="_blank"`;
 

--- a/content.js
+++ b/content.js
@@ -1,24 +1,15 @@
-var pullRequestTitleElement = document.getElementsByClassName('js-issue-title')[0];
+(() => {
+  const $title = document.querySelector('.js-issue-title');
+  if (!$title) {
+    return;
+  }
 
-if (pullRequestTitleElement) {
-  var title = pullRequestTitleElement.innerHTML.replace(/(<a[^>]+>|<\/a>)/g, '');
+  let title = $title.innerHTML.replace(/(<a[^>]+>|<\/a>)/g, '');
 
-  // Gets an array of matched ids: [[#12345], [#34563], ...]
-  var trackerIds = title.match(/\[#(.*?)\]\s*/g);
-  var links = '';
-  var idsToBeReplaced = '';
-
-  trackerIds.forEach(function(id) {
-    // Concatenates the matched ids which will be replaced by links
-    idsToBeReplaced += id;
-
-    var rawTrackerId = id.match(/\d+/g);
-    links += '<a href="https://www.pivotaltracker.com/story/show' +
-    rawTrackerId +
-    '" target="_blank">[#' +
-    rawTrackerId +
-    ']</a>';
+  title.match(/\[#\d+\]/g).forEach((tag) => {
+    const url = `https://www.pivotaltracker.com/story/show/${tag.match(/\d+/)}`;
+    title = title.replace(tag, `<a href="${url}" target="_blank">${tag}</a>`);
   });
 
-  pullRequestTitleElement.innerHTML = title.replace(idsToBeReplaced, links);
-}
+  $title.innerHTML = title;
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -14,8 +14,11 @@
     "persistent": false
   },
 
+  "options_page": "options.html",
+
   "permissions": [
    "activeTab",
+   "storage",
    "https://www.github.com/BLC/*",
    "https://github.com/BLC/*",
    "https://github.com/joshuaheng/pivotal-github-chrome/*"

--- a/options.html
+++ b/options.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <script src="options.js" async></script>
+  </head>
+
+  <body>
+  </body>
+</html>

--- a/options.html
+++ b/options.html
@@ -4,5 +4,7 @@
   </head>
 
   <body>
+    <input id="inline-links" type="checkbox" />
+    <label>Inline links?</label>
   </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,11 @@
+const $inlineLinksInput = document.querySelector('#inline-links');
+
+chrome.storage.local.get('inlineLinks', (options) => {
+  if (options.inlineLinks !== false) {
+    $inlineLinksInput.setAttribute('checked', 'checked');
+  }
+});
+
+$inlineLinksInput.addEventListener('change', () => {
+  chrome.storage.local.set({ inlineLinks: $inlineLinksInput.checked });
+});


### PR DESCRIPTION
I found this project really useful. However, my personal workflow for PR review consists of copy/pasting the tracker ID from a PR directly to Everhour. Replacing the IDs with links made that more difficult, so I added an option to include a separate link instead (off by default).

In addition, I got a little carried away, so this also:
- Fixes a bug where switching between PR tabs quickly would generate multiple links
  - It was not noticeable with the inline links as it just kept creating empty ones, but the separate links made it pretty obvious
- Decouples the project from the NC Pivotal project
  - Stories can be linked to directly without the Project ID in the URL
- Supports both formats of multiple tags
  - `[#123] [#456]` and `[#123, #456]` are both valid
- ES6ifies the code
  - It is a Chrome extension after all, so there is native ES6 support

I've been using this version locally for a week or so now without issue, for what it's worth.
